### PR TITLE
Specify hook type

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -2,6 +2,7 @@
     name: bandit
     description: Python code vulnerabilities checker
     language: python
+    types: [python]
     entry: bandit_analyzer
     args: [-lll, --recursive, .]
     files: ''


### PR DESCRIPTION
Fixes running `bandit` check on non-python files. Filter files by hook type. 

See https://pre-commit.com/#pre-commit-configyaml---hooks