### PR TITLE
Use Github Actions instead of TravisCI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  check:
+    name: Run check
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.7"
+
+      - name: Cache pip
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cache/pip
+            ~/.cache/pre-commit
+          key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
+            ${{ runner.os }}-pip
+
+      - name: Upgrade pip
+        run: python -m pip install --upgrade pip setuptools wheel
+
+      - name: Install dependencies
+        run:  pip install -U -r dev-requirements.txt
+
+      - name: Install package
+        run:  pip install -U .
+
+      - name: Build package
+        run:  pre-commit run --all-files --verbose

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,8 +26,9 @@ repos:
     -   id: python-bandit-vulnerability-check
 -   repo: local
     hooks:
-    -   id: py.test
-        name: py.test
+    -   id: pytest
+        name: pytest
         language: system
-        entry: sh -c py.test
+        entry: sh -c pytest
         files: \.py$
+        pass_filenames: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,0 @@
-language: python
-python:
-  - "3.7"
-install: pip install -U . -r dev-requirements.txt
-script: pre-commit run --all-files --verbose


### PR DESCRIPTION
TravisCI site shows this notice:
"Please be aware travis-ci.org will be shutting down in several weeks"

Let's move CI to Github Actions. This is an example of a successful workflow run:
https://github.com/dolfinus/pre-commit-hooks-bandit/runs/2390992306