### PR TITLE
Add name variable to example

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,4 +45,5 @@ You'll need to `pip install bandit` beforehand:
         args: [-lll, --recursive, .]
         language: system
         files: ''
+        name: bandit
 ```


### PR DESCRIPTION
I found I needed to add this to the example to avoid;

```
An error has occurred: InvalidConfigError:
==> File .pre-commit-config.yaml
==> At Config()
==> At key: repos
==> At Repository(repo='local')
==> At key: hooks
==> At Hook(id='python-bandit-vulnerability-check')
=====> Missing required key: name
```